### PR TITLE
explorer/cpu_cores: Update /proc/cpuinfo parsing

### DIFF
--- a/explorer/cpu_cores
+++ b/explorer/cpu_cores
@@ -38,12 +38,10 @@ case "$os" in
     ;;
 
     *)
-        if [ -r /proc/cpuinfo ]; then
-            cores="$(grep "core id" /proc/cpuinfo | sort | uniq | wc -l)"
-            if [ "${cores}" -eq 0 ]; then
-                cores="1"
-            fi
-            echo "$cores"
+        if test -r /proc/cpuinfo
+        then
+            cores=$(grep -c -e '^processor[[:blank:]]*:' /proc/cpuinfo)
+            test $((cores)) -ge 1 && echo $((cores)) || echo 1
         fi
     ;;
 esac


### PR DESCRIPTION
Not all architectures have a core id property.
It was introduced ~3.13 for x86.
Replacing it with counting processor lines should work on all architectures.