### PR TITLE
Misc. fixes primarily for OpenWrt

### DIFF
--- a/type/__link/explorer/state
+++ b/type/__link/explorer/state
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # 2012-2014 Steven Armstrong (steven-cdist at armstrong.cc)
+# 2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -28,13 +29,32 @@ if [ ! -e "$destination" ]; then
    exit 0
 fi
 
+_readlink() {
+	if command -v readlink >/dev/null 2>&1
+	then
+		readlink "$1"
+	else
+		# resort to parsing the output of ls(1)
+		if ls -Ldl "$1" | grep -q '^d'
+		then
+			# resolve destination of symlinks pointing to a directory
+			(cd "$1" && pwd -P)
+		else
+			# resolve destination of symlinks pointing to a file
+			_ls_out=$(ls -l "$1")
+			echo "${_ls_out#*$1 -> }"
+			unset _ls_out
+		fi
+	fi
+}
+
 destination_dir="${destination%/*}"
 
 case "$type" in
    symbolic)
       cd "$destination_dir" || exit 1
       if [ -h "$destination" ]; then
-         source_is=$(readlink "$destination")
+         source_is=$(_readlink "${destination}")
          # ignore trailing slashes for comparison
          if [ "${source_is%/}" = "${source%/}" ]; then
             echo present

--- a/type/__uci/explorer/state
+++ b/type/__uci/explorer/state
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 #
-# 2020,2022 Dennis Camera (cdist at dntr.ch)
+# 2020,2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -30,6 +30,10 @@
 #   rearranged
 #     The configuration option is present (a list) and has the same values as
 #     the parameter --value, but in a different order.
+
+# NOTE: older releases of OpenWrt do not include sbin in PATH but uci(1) is
+#       installed in /sbin.
+PATH=/bin:/sbin:/usr/bin:/usr/sbin
 
 RS=$(printf '\036')
 

--- a/type/__uci/files/uci_apply.sh
+++ b/type/__uci/files/uci_apply.sh
@@ -1,3 +1,7 @@
+# NOTE: older releases of OpenWrt do not include sbin in PATH but uci(1) is
+#       installed in /sbin.
+PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
 changes=$(uci changes)
 
 if test -n "${changes}"

--- a/type/__user/gencode-remote
+++ b/type/__user/gencode-remote
@@ -4,6 +4,7 @@
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2013 Daniel Heule (hda at sfs.biz)
 # 2018 Thomas Eckert (tom at it-eckert.de)
+# 2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -23,7 +24,6 @@
 #
 # Manage users.
 #
-#set -x
 
 name="$__object_id"
 
@@ -48,6 +48,57 @@ shorten_property() {
     system) ret="-r";;
     esac
     echo "$ret"
+}
+
+quote_ifneeded() {
+	# copied from type/__uci/files/functions.sh
+	for _arg
+	do
+		shift
+		if test -n "$(printf %s "${_arg}" | tr -d -c '\t\n \042-\047\050-\052\073-\077\133\\`|~' | tr -c '' '.')"
+		then
+			# needs quoting
+			set -- "$@" "'$(printf '%s\n' "${_arg}" | sed -e "s/'/'\\\\''/g")'"
+		else
+			set -- "$@" "${_arg}"
+		fi
+	done
+	unset _arg
+
+	# NOTE: Use printf because POSIX echo interprets escape sequences
+	printf '%s' "$*"
+}
+
+
+do_user() {
+	_util_name=user$1
+	_user_name=$2
+	shift; shift
+
+	set -- "${_util_name}" "$@"
+
+	case ${os:?}
+	in
+		(freebsd)
+			# FreeBSD uses the pw wrapper utility
+			set -- pw "$@"
+
+			# user name is -n option
+			set -- "$@" -n
+			;;
+		(openwrt)
+			# NOTE: older releases of OpenWrt do not include sbin in PATH, but
+			#       user* utilities are installed in /usr/sbin.
+			echo 'PATH=/bin:/sbin:/usr/bin:/usr/sbin'
+			;;
+	esac
+	# append user name as last argument
+	set -- "$@" "${_user_name}"
+
+	# quote arguments if needed
+	quote_ifneeded "$@"; echo
+
+	unset _util_name _user_name
 }
 
 if [ "$state" = "present" ]; then
@@ -104,11 +155,8 @@ if [ "$state" = "present" ]; then
 
        if [ $# -gt 0 ]; then
           echo mod >> "$__messages_out"
-          if [ "$os" = "freebsd" ]; then
-             echo pw usermod "$@" -n "$name"
-          else
-             echo usermod "$@" "$name"
-          fi
+
+          do_user mod "${name}" "$@"
        else
           true
        fi
@@ -125,30 +173,18 @@ if [ "$state" = "present" ]; then
             fi
         done
 
-       if [ "$os" = "freebsd" ]; then
-          echo pw useradd "$@" -n "$name"
-       else
-          echo useradd "$@" "$name"
-       fi
+       do_user add "${name}" "$@"
     fi
 elif [ "$state" = "absent" ]; then
     if grep -q "^${name}:" "$__object/explorer/passwd"; then
         #user exists, but state != present, so delete it
-        if [ -f "$__object/parameter/remove-home" ]; then
-            if [ "$os" = "freebsd" ]; then
-                printf "pw userdel '%s' -r >/dev/null 2>&1\\n" "${name}"
-            else
-                printf "userdel -r '%s' >/dev/null 2>&1\\n" "${name}"
-            fi
-            echo "userdel -r" >> "$__messages_out"
-        else
-            if [ "$os" = "freebsd" ]; then
-                printf "pw userdel '%s' >/dev/null 2>&1\\n" "${name}"
-            else
-                printf "userdel '%s' >/dev/null 2>&1\\n" "${name}"
-            fi
-            echo "userdel" >> "$__messages_out"
+        set --
+        if [ -f "${__object:?}/parameter/remove-home" ]; then
+            set -- "$@" -r
         fi
+
+        do_user del "${name}" "$@"
+        echo "userdel $*" >>"${__messages_out:?}"
     fi
 else
     echo "Invalid state $state" >&2

--- a/type/__user/manifest
+++ b/type/__user/manifest
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # 2019 Nico Schottelius (nico-cdist at schottelius.org)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020,2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -30,6 +30,14 @@ in
 		case $(cat "${__object}/parameter/state")
 		in
 			(present)
+				if test -f "${__object:?}/parameter/create-home"
+				then
+					# NOTE: OpenWrt does not have /home by default.
+					#       __user --create-home would thus error:
+					#
+					#       useradd: cannot create directory /home/user
+					__directory /home --owner 0 --group 0 --mode 0755
+				fi
 				if test -s "${__object}/explorer/passwd"
 				then
 					# NOTE: The package might not be required if no changes


### PR DESCRIPTION
While trying to configure more OpenWrt devices I stumbled over some cases that didn't work properly.
The ones I found are fixed in this PR.

**__uci**:
- On old OpenWrt releases the `PATH` was set incorrectly when running scripts via `ssh root@openwrt /bin/sh -c` (as cdist does).
  This problem is not limited to OpenWrt, though, so maybe we'd want to solve the issue of setting the `PATH` correctly in cdist-core.

**__user**:
- OpenWrt does not have a `/home` by default, leading to failure when the `__user` type is used to manipulate non-root users.
- There were also `PATH` issues here.
  To not introduce any more code duplication, I rewrote `gencode-remote` and extracted handling of the specialties for FreeBSD and OpenWrt into a separate `do_user` function.

**__link**:
- The `__link` type has been updated to work without `readline(1)`.
  It is non-POSIX and not present on some systems.