### PR TITLE
__package_opkg: Run opkg update when necessary

### DIFF
--- a/type/__package_opkg/explorer/pkg_status
+++ b/type/__package_opkg/explorer/pkg_status
@@ -92,7 +92,7 @@ if opkg status "${pkg_name}" 2>/dev/null \
 	| grep -q -e '^Status: [^ ][^ ]* [^ ][^ ]* installed$'
 then
 	echo 'present'
-elif opkg info "${pkg_name}" 2>/dev/null | grep -q .
+elif opkg list "${pkg_name}" 2>/dev/null | grep -q .
 then
 	echo 'absent'
 else

--- a/type/__package_opkg/explorer/pkg_status
+++ b/type/__package_opkg/explorer/pkg_status
@@ -2,7 +2,7 @@
 #
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2012 Giel van Schijndel (giel plus cdist at mortis dot eu)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020,2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
 #
 # This file is part of cdist.
 #
@@ -23,7 +23,8 @@
 # Retrieve the status of a package - parses opkg output
 #
 
-readonly __type_path=${__object%%${__object_id}*}
+: "${__object:?}"  # assert __object is set
+readonly __type_path=${__object%%${__object_id:?}*}
 test -d "${__type_path}" || { echo 'Cannot determine __type_path' >&2; exit 1; }
 readonly LOCKFILE="${__type_path:?}/.cdist_opkg.lock"
 
@@ -66,11 +67,11 @@ else
 fi
 
 
-if test -f "${__object}/parameter/name"
+if test -f "${__object:?}/parameter/name"
 then
-	pkg_name=$(cat "${__object}/parameter/name")
+	pkg_name=$(cat "${__object:?}/parameter/name")
 else
-	pkg_name=$__object_id
+	pkg_name=${__object_id:?}
 fi
 
 

--- a/type/__package_opkg/explorer/pkg_status
+++ b/type/__package_opkg/explorer/pkg_status
@@ -2,7 +2,7 @@
 #
 # 2011 Nico Schottelius (nico-cdist at schottelius.org)
 # 2012 Giel van Schijndel (giel plus cdist at mortis dot eu)
-# 2020,2022 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020,2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -24,9 +24,11 @@
 #
 
 : "${__object:?}"  # assert __object is set
-readonly __type_path=${__object%%${__object_id:?}*}
+__type_path=${__object%%${__object_id:?}*}
+readonly __type_path
 test -d "${__type_path}" || { echo 'Cannot determine __type_path' >&2; exit 1; }
-readonly LOCKFILE="${__type_path:?}/.cdist_opkg.lock"
+LOCKFILE="${__type_path:?}/.cdist_opkg.lock"
+readonly LOCKFILE
 
 if command -v flock >/dev/null 2>&1
 then

--- a/type/__package_opkg/explorer/pkg_status
+++ b/type/__package_opkg/explorer/pkg_status
@@ -92,7 +92,7 @@ then
 	echo 'present'
 elif opkg info "${pkg_name}" 2>/dev/null | grep -q .
 then
-	echo 'absent notpresent'
-else
 	echo 'absent'
+else
+	echo 'absent notpresent'
 fi

--- a/type/__package_opkg/gencode-remote
+++ b/type/__package_opkg/gencode-remote
@@ -2,7 +2,7 @@
 #
 # 2011,2013 Nico Schottelius (nico-cdist at schottelius.org)
 # 2012 Giel van Schijndel (giel plus cdist at mortis dot eu)
-# 2020 Dennis Camera (dennis.camera at ssrq-sds-fds.ch)
+# 2020,2022 Dennis Camera (cdist at dtnr.ch)
 #
 # This file is part of cdist.
 #
@@ -23,23 +23,16 @@
 # Manage packages on OpenWrt, optware, and co.
 #
 
-if test -f "${__object}/parameter/name"
+quote() { printf '%s\n' "$*" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/'/"; }
+
+if test -f "${__object:?}/parameter/name"
 then
-	name=$(cat "${__object}/parameter/name")
+	name=$(cat "${__object:?}/parameter/name")
 else
-	name=$__object_id
+	name=${__object_id:?}
 fi
-
-state_should=$(cat "${__object}/parameter/state")
-state_is=$(cat "${__object}/explorer/pkg_status")
-
-case $state_is
-in
-	(absent*)
-		presence=$(echo "${state_is}" | cut -d ' ' -f 2)
-		state_is='absent'
-		;;
-esac
+state_should=$(cat "${__object:?}/parameter/state")
+read -r state_is presence <"${__object:?}/explorer/pkg_status"
 
 if test "${state_is}" = "${state_should}"
 then
@@ -47,7 +40,7 @@ then
 fi
 
 
-case $state_should
+case ${state_should}
 in
 	(present)
 		if test "${presence}" = 'notpresent'
@@ -55,12 +48,12 @@ in
 			echo 'opkg --verbosity=0 update'
 		fi
 
-		printf "opkg --verbosity=0 install '%s'\n" "${name}"
-		echo 'installed' >>"${__messages_out}"
+		printf 'opkg --verbosity=0 install %s\n' "$(quote "${name}")"
+		echo 'installed' >>"${__messages_out:?}"
 		;;
 	(absent)
-		printf "opkg --verbosity=0 remove '%s'" "${name}"
-		echo 'removed' >>"${__messages_out}"
+		printf 'opkg --verbosity=0 remove %s\n' "$(quote "${name}")"
+		echo 'removed' >>"${__messages_out:?}"
 		;;
 	(*)
 		printf 'Unknown state: %s\n' "${state_should}" >&2


### PR DESCRIPTION
This PR fixes a logic error that is present in the `pkg_status` explorer.
It prints the `notpresent` flag when `opkg info` actually found a package, and does not print it when OPKG does not know about a package.

This logic is inverted in this PR (as it should be).
I also did some linting, implemented safer quoting of package names and fixed two minor issues that occurred with different versions of OpenWrt:
- older versions of Busybox (didn't check which exactly) don't like it using `readonly` and immediately assigning a variable.
- On OpenWrt 19.07 the `opkg info` command seems to never print anything.