### PR TITLE
explorer/disks: Add Solaris support

### DIFF
--- a/explorer/disks
+++ b/explorer/disks
@@ -60,6 +60,10 @@ case $uname_s in
         fi
     ;;
     SunOS)
+        # NOTE: format(1m) - disk partitioning and maintenance utility.
+        #       When called with no arguments, it will print a list of disks it
+        #       can find and prompt the user to select one.
+        #       passing in /dev/null as stdin will cancel the disk selection.
         format </dev/null \
         | sed -n \
               -e '1,/^AVAILABLE DISK/d' \

--- a/explorer/disks
+++ b/explorer/disks
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # based on previous work by other people, modified by:
-# 2020 Dennis Camera <dennis.camera at ssrq-sds-fds.ch>
+# 2020,2022 Dennis Camera <cdist at dtnr.ch>
 #
 # This file is part of cdist.
 #
@@ -61,14 +61,10 @@ case $uname_s in
     ;;
     SunOS)
         format </dev/null \
-        | awk '
-            BEGIN {
-              getline
-              while ($0 !~ /^AVAILABLE DISK/) getline
-            }
-            /^ +[0-9]+\. /' \
-        | sed -e 's/^ *[0-9][0-9]*. //' \
-        | cut -d' ' -f1
+        | sed -n \
+              -e '1,/^AVAILABLE DISK/d' \
+              -e 's/^ *[0-9]\{1,\}\. //p' \
+        | cut -d ' ' -f 1
     ;;
     *)
         printf "Don't know how to list disks for %s operating system.\n" "${uname_s}" >&2

--- a/explorer/disks
+++ b/explorer/disks
@@ -59,6 +59,17 @@ case $uname_s in
             echo 'If you can, please submit a patch.'>&2
         fi
     ;;
+    SunOS)
+        format </dev/null \
+        | awk '
+            BEGIN {
+              getline
+              while ($0 !~ /^AVAILABLE DISK/) getline
+            }
+            /^ +[0-9]+\. /' \
+        | sed -e 's/^ *[0-9][0-9]*. //' \
+        | cut -d' ' -f1
+    ;;
     *)
         printf "Don't know how to list disks for %s operating system.\n" "${uname_s}" >&2
         printf 'If you can please submit a patch\n' >&2


### PR DESCRIPTION
Adds disks detection code for Solaris.
Tested on:
* Sun Solaris 10 10/09*
* Oracle Solaris 11.2
* OmniOS CE v11 r151030v
* OpenIndiana Hipster 20190511
* Tribblix m17
on i86pc.

*) only works with `/usr/xpg4/bin/sh` which is an issue for other parts of cdist, too.