### PR TITLE
__user: Fix double quotation

### DIFF
--- a/type/__user/gencode-remote
+++ b/type/__user/gencode-remote
@@ -149,7 +149,7 @@ if [ "$state" = "present" ]; then
           fi
 
           if [ "$new_value" != "$current_value" ]; then
-              set -- "$@" "$(shorten_property "$property")" \'"$new_value"\'
+              set -- "$@" "$(shorten_property "$property")" "$new_value"
           fi
        done
 
@@ -169,7 +169,7 @@ if [ "$state" = "present" ]; then
             if [ -z "$new_value" ];then       # Boolean values have no value
               set -- "$@" "$(shorten_property "$property")"
             else
-              set -- "$@" "$(shorten_property "$property")" \'"$new_value"\'
+              set -- "$@" "$(shorten_property "$property")" "$new_value"
             fi
         done
 


### PR DESCRIPTION
PR #14 introduced a bug in the `__user` type that led to some arguments being quoted twice.

Fixes #21.