### PR TITLE
__download: change tmpfile to be in the destdir

### DIFF
--- a/type/__download/gencode-local
+++ b/type/__download/gencode-local
@@ -39,7 +39,7 @@ else
     exit 1
 fi
 
-echo "download_tmp=\"\$( mktemp )\""
+echo "download_tmp=\"$__object/files/download_file\""
 
 # shellcheck disable=SC2059
 printf "$cmd > \"\$download_tmp\"\n" "$url"

--- a/type/__download/gencode-local
+++ b/type/__download/gencode-local
@@ -39,7 +39,8 @@ else
     exit 1
 fi
 
-echo "download_tmp=\"$__object/files/download_file\""
+echo "mkdir \"$__object/files\""
+echo "download_tmp=\"$__object/files/download_tmp\""
 
 # shellcheck disable=SC2059
 printf "$cmd > \"\$download_tmp\"\n" "$url"

--- a/type/__download/gencode-remote
+++ b/type/__download/gencode-remote
@@ -17,7 +17,7 @@ then
         dst="/$__object_id"
     fi
 
-    echo "download_tmp=\"\$( mktemp '$dst'.XXXXXXXX )\""
+    echo "download_tmp=\"${dst}.cdist__download_tmp\""
 
     # shellcheck disable=SC2059
     printf "$cmd_get > \"\$download_tmp\"\n" "$url"

--- a/type/__download/gencode-remote
+++ b/type/__download/gencode-remote
@@ -17,7 +17,7 @@ then
         dst="/$__object_id"
     fi
 
-    echo "download_tmp=\"\$( mktemp )\""
+    echo "download_tmp=\"\$( mktemp '$dst'.XXXXXXXX )\""
 
     # shellcheck disable=SC2059
     printf "$cmd_get > \"\$download_tmp\"\n" "$url"


### PR DESCRIPTION
Happend to me to download a very big file, which overflows `/tmp`. This will name the temp file similar to the original except the random pattern `mktemp` appends.

If this isn't much distinguishable, we can add more to the filename.

Currently it's only done for remote downloads, not for local ones. If the same should be done for local downloads, then it's a question where to download the files.