### PR TITLE
__download: silent wget output and progress status

### DIFF
--- a/type/__download/explorer/remote_cmd_get
+++ b/type/__download/explorer/remote_cmd_get
@@ -12,5 +12,5 @@ elif
 then
     echo "fetch -o - '%s'"
 else
-    echo "wget -O - '%s'"
+    echo "wget -q -O - '%s'"
 fi

--- a/type/__download/gencode-local
+++ b/type/__download/gencode-local
@@ -32,7 +32,7 @@ then
 
 elif command -v wget > /dev/null
 then
-    cmd="wget -O - '%s'"
+    cmd="wget -q -O - '%s'"
 
 else
     echo 'local download failed, no usable utility' >&2


### PR DESCRIPTION
`wget` really spams with it's progress output, mostly because it's send a new line each time it changes. This will use a bit more unneceesary bandwith for the ssh session for this useless feature.

Because there wasn't another option, `wget` is now quiet by default, just like `curl` does now. Should be ok to only output on error. Can't speak for `fetch` how verbose it is.