### PR TITLE
__file: if state=absent, remove symlinks too

### DIFF
--- a/type/__file/gencode-remote
+++ b/type/__file/gencode-remote
@@ -88,7 +88,7 @@ case "$state_should" in
     ;;
 
     absent)
-        if [ "$type" = "file" ]; then
+        if [ "$type" = "file" ] || [ "$type" = "symlink" ]; then
             echo "rm -f '$destination'"
             echo remove >> "$__messages_out"
             fire_onchange=1

--- a/type/__file/man.rst
+++ b/type/__file/man.rst
@@ -19,7 +19,7 @@ regular file, and state is:
   exists
     do nothing
 symlink
-  replace it with the source file
+  replace it with the source file or remove
 directory
   replace it with the source file
 


### PR DESCRIPTION
Again I stumbled on situation where in one system, file which I want to get rid of, is real file and in another it's actually symlink (due to various legacy and non-technical reasons). It's not possible to use `__link` in my situation because I don't know the `--source`.

I think it makes totally sense to also remove symlinks if `--state absent`, because you don't care if it's real file or symlink - you just want that file gone.