### PR TITLE
__git: Install ca-certificates for https repos on Debian

### DIFF
--- a/type/__git/manifest
+++ b/type/__git/manifest
@@ -32,6 +32,19 @@ mode="$(cat "$__object/parameter/mode")"
 
 case "$state_should" in
     present)
+        source=$(cat "${__object:?}/parameter/source")
+        case ${source}
+        in
+            (https://*)
+                os=$(cat "${__global:?}/explorer/os")
+                case ${os}
+                in
+                    (debian|devuan|ubuntu)
+                        __package_apt ca-certificates
+                        ;;
+                esac
+                ;;
+        esac
         :
     ;;
 


### PR DESCRIPTION
Trying to clone a Git repo over HTTPS fails on Debian if ca-certificates is not installed.

The problem might also apply to other OSes, but I haven't tested that.