### PR TITLE
__file: Fixup to #36

### DIFF
--- a/type/__file/gencode-local
+++ b/type/__file/gencode-local
@@ -99,12 +99,7 @@ if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
       # c) the only case which we could improve are tmp directories and we
       #    don't think managing tmp directories with cdist is a typical case
       #    ("the rest %)"
-      cat << DONE
-$__remote_exec $__target_host test -e $upload_destination && {
-   echo "Refusing to upload file to existing destination: $upload_destination" >&2
-   exit 1
-}
-DONE
+
       # Tell gencode-remote to where we uploaded the file so it can move
       # it to its final destination.
       echo "$upload_destination" > "$__object/files/upload-destination"

--- a/type/__file/gencode-local
+++ b/type/__file/gencode-local
@@ -89,7 +89,7 @@ if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
       touch "$__object/files/set-attributes"
 
       # upload file to temp location
-      upload_destination="$(mktemp -u "${destination}.cdist.XXXXXXXXXX")"
+      upload_destination="$(mktemp -u "/__cdist${destination}.cdist.XXXXXXXXXX" | sed 's|^/__cdist||')"
       # Yes, we are aware that this is a race condition.
       # However:
       # a) cdist usually writes to directories that are not user writable

--- a/type/__file/gencode-local
+++ b/type/__file/gencode-local
@@ -72,6 +72,7 @@ if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
          if [ "$type" != "file" ]; then
             # destination is not a regular file, upload source to replace it
             upload_file=1
+            echo upload >> "$__messages_out"
          else
             local_cksum="$(cksum < "$source")"
             remote_cksum="$(cat "$__object/explorer/cksum")"
@@ -87,6 +88,14 @@ if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
       # set all attributes no matter what the explorer retreived
       mkdir "$__object/files"
       touch "$__object/files/set-attributes"
+
+      if [ "$create_file" ]; then
+         # When creating an empty file we create it locally and then
+         # upload it so that permissions can be set before moving the file
+         # into place.
+         source="$__object/files/empty"
+         touch "$source"
+      fi
 
       # upload file to temp location
       upload_destination="$(mktemp -u "/__cdist${destination}.cdist.XXXXXXXXXX" | sed 's|^/__cdist||')"
@@ -104,18 +113,15 @@ if [ "$state_should" = "present" ] || [ "$state_should" = "exists" ]; then
       # it to its final destination.
       echo "$upload_destination" > "$__object/files/upload-destination"
 
-      if [ "$upload_file" ]; then
-         echo upload >> "$__messages_out"
-         # IPv6 fix
-         if echo "${__target_host}" | grep -q -E '^[0-9a-fA-F:]+$'
-         then
-             my_target_host="[${__target_host}]"
-         else
-             my_target_host="${__target_host}"
-         fi
-         cat << DONE
+      # IPv6 fix
+      if echo "${__target_host}" | grep -q -E '^[0-9a-fA-F:]+$'
+      then
+          my_target_host="[${__target_host}]"
+      else
+          my_target_host="${__target_host}"
+      fi
+      cat << DONE
 $__remote_copy "$source" "${my_target_host}:${upload_destination}"
 DONE
-      fi
    fi
 fi


### PR DESCRIPTION
Still not a fan of the changes to the `__file` type but I'm making a PR to stay consistent with cdist-ungleich.
Hopefully this version is less broken than the previous one :-)

I'm not sure if the `mktemp -u` hack to prefix the template with `/__cdist` really works…
Is it granted that every user on every config host has read (and write?) access to `/`?