### PR TITLE
Extend __unpack cases to support .txz and .tbz2

### DIFF
--- a/type/__unpack/gencode-remote
+++ b/type/__unpack/gencode-remote
@@ -14,7 +14,7 @@ dst="$( sed 's/\/$//' "$__object/parameter/destination" )"
 cmd=''
 
 case "$src" in
-    *.tar|*.tgz|*.tar.*)
+    *.tar|*.tgz|*.tar.*|*.txz|*.tbz2)
         cmd="mkdir -p '$dst' && tar --directory='$dst' --extract --file='$src'"
 
         if [ -f "$__object/parameter/tar-strip" ]

--- a/type/__unpack/man.rst
+++ b/type/__unpack/man.rst
@@ -8,9 +8,9 @@ cdist-type__unpack - Unpack archives
 
 DESCRIPTION
 -----------
-Unpack ``.tar``, ``.tgz``, ``.tar.*``, ``.7z``, ``.bz2``, ``.gz``,
-``.lzma``, ``.xz``, ``.rar`` and ``.zip`` archives. Archive type is
-detected by extension.
+Unpack ``.tar``, ``.tgz``, ``.tar.*``, ``.txz``, ``.tbz2``, ``.7z``,
+``.bz2``, ``.gz``, ``.lzma``, ``.xz``, ``.rar`` and ``.zip`` archives.
+Archive type is detected by extension.
 
 To achieve idempotency, checksum file will be created in target. See
 ``--sum-file`` parameter for details.

--- a/type/__unpack/manifest
+++ b/type/__unpack/manifest
@@ -8,7 +8,7 @@ case "$src" in
     *.7z)
         __package p7zip
     ;;
-    *.bz2)
+    *.bz2|*.tbz2)
         case "$os" in
             freebsd)
                 # bzip2 is part of freebsd base system


### PR DESCRIPTION
Copy of ungleich/cdist#785.

Original description:
> `cdist/conf/type/__unpack/manifest` already had a case for `.txz` but it was missing from the gencode-local code. Also added .bz2 support while here.
> 
> Ran into this as FreeBSD base sets are distributed as `.txz` files.

