### PR TITLE
__package_pip: Fall back to __object_id if the package name can't be deduced from --requirement

### DIFF
--- a/type/__package_pip/explorer/state
+++ b/type/__package_pip/explorer/state
@@ -43,11 +43,41 @@ test -n "${pyinterp}" || {
 }
 
 # Execute the matching Python interpreter of pip.
-pip_python() { eval set -- "${pyinterp}" '"$@"'; "$@"; }
+# shellcheck disable=SC2120
+pip_python() { eval "set -- \"${pyinterp}\" \"\$@"\"; "$@"; }
 
-requirement=$("${__type_explorer:?}/requirement")
+REQUIREMENT=$("${__type_explorer:?}/requirement")
+export REQUIREMENT
 
-pip_python -c '__import__("pkg_resources").require(__import__("sys").argv[1])' \
-	"${requirement}" >/dev/null 2>&1 \
-&& echo present \
-|| echo absent
+pip_python <<CODE
+import pkg_resources
+import os
+import sys
+
+
+def check_requirement(r):
+    try:
+        pkg_resources.require(requirement)
+        return "present"
+    except pkg_resources.DistributionNotFound:
+        return "absent"
+
+
+def println(line, file):
+    file.write(line + "\n")
+
+
+requirement = os.environ["REQUIREMENT"]
+
+try:
+    println(check_requirement(requirement), sys.stdout)
+except pkg_resources.RequirementParseError:
+    # requirement is probably an URL, fall back to __object_id
+    requirement = os.environ["__object_id"]
+    println(check_requirement(requirement), sys.stdout)
+
+except pkg_resources.UnknownExtra as e:
+    # unknown extras are not acceptable
+    println(str(e), sys.stderr)
+    sys.exit(1)
+CODE

--- a/type/__package_pip/man.rst
+++ b/type/__package_pip/man.rst
@@ -20,6 +20,16 @@ Most OSes provide a package to get a default pip installation, so it's usually
 sufficient to add ``__package python3-pip`` to your manifest.
 
 
+**Caveat:** This type can only do proper state detection if the
+``--requirement`` is the name of a package in the PyPI index.
+If it is a URL, this type can only check if the package is already install but
+not e.g. switch a Git branch, because the installed branch is not tracked by the
+package manager.
+Furthermore, if a URL does not start with ``[packagename]@``, the type will fall
+back to assume the ``__object_id`` contains the package name what would be
+installed by the given ``--requirement``.
+
+
 REQUIRED PARAMETERS
 -------------------
 None


### PR DESCRIPTION
This PR should fix #45.

Please test.