### PR TITLE
Handle signed-by option in __apt_source

### DIFF
--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -2,6 +2,8 @@
 set -u
 
 entry="$uri $distribution $component"
+options="$forcedarch $signed_by"
+options=${options## }; options=${options%% }
 
 cat << DONE
 # Created by cdist ${__type##*/}
@@ -9,8 +11,8 @@ cat << DONE
 #
 
 # $name
-deb ${options} $entry
+deb ${options:+[${options}] }$entry
 DONE
 if [ -f "$__object/parameter/include-src" ]; then
-   echo "deb-src $entry"
+   echo "deb-src ${signed_by:+[${signed_by}] }$entry"
 fi

--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -2,13 +2,14 @@
 set -u
 
 entry="$uri $distribution $component"
+
 cat << DONE
 # Created by cdist ${__type##*/}
 # Do not change. Changes will be overwritten.
 #
 
 # $name
-deb ${forcedarch} $entry
+deb ${options} $entry
 DONE
 if [ -f "$__object/parameter/include-src" ]; then
    echo "deb-src $entry"

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -24,7 +24,7 @@ arch
    set this if you need to force and specific arch (ubuntu specific)
 
 signed-by
-   provide a GPG key fingerprint or keyring path for signature checks
+   provide a GPG key fingerprint or keyring path for signature checks. May be repeated.
 
 state
    'present' or 'absent', defaults to 'present'
@@ -68,6 +68,7 @@ EXAMPLES
 AUTHORS
 -------
 Steven Armstrong <steven-cdist--@--armstrong.cc>
+Daniel Fancsali <fancsali--@--gmail.com>
 
 
 COPYING

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -37,7 +37,7 @@ component
 OPTIONAL MULTIPLE PARAMETERS
 ----------------------------
 signed-by
-   provide a GPG key fingerprint or keyring path for signature checks. May be repeated.
+   provide a GPG key fingerprint or keyring path for signature checks.
 
 
 BOOLEAN PARAMETERS

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -23,6 +23,9 @@ OPTIONAL PARAMETERS
 arch
    set this if you need to force and specific arch (ubuntu specific)
 
+signed-by
+   provide a GPG key fingerprint or keyring path for signature checks
+
 state
    'present' or 'absent', defaults to 'present'
 
@@ -55,6 +58,11 @@ EXAMPLES
     __apt_source canonical_partner \
        --uri http://archive.canonical.com/ \
        --component partner --state present
+
+    __apt_source goaccess \
+       --uri http://deb.goaccess.io/ \
+       --component main \
+       --signed-by C03B48887D5E56B046715D3297BD1A0133449C3D
 
 
 AUTHORS

--- a/type/__apt_source/man.rst
+++ b/type/__apt_source/man.rst
@@ -23,9 +23,6 @@ OPTIONAL PARAMETERS
 arch
    set this if you need to force and specific arch (ubuntu specific)
 
-signed-by
-   provide a GPG key fingerprint or keyring path for signature checks. May be repeated.
-
 state
    'present' or 'absent', defaults to 'present'
 
@@ -35,6 +32,12 @@ distribution
 
 component
    space delimited list of components to enable. Defaults to an empty string.
+
+
+OPTIONAL MULTIPLE PARAMETERS
+----------------------------
+signed-by
+   provide a GPG key fingerprint or keyring path for signature checks. May be repeated.
 
 
 BOOLEAN PARAMETERS

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -35,7 +35,7 @@ if [ -f "$__object/parameter/arch" ]; then
 fi
 
 if [ -f "$__object/parameter/signed-by" ]; then
-   signed_by="${signed_by:${signed_by} }signed-by=$(cat "$__object/parameter/signed-by")"
+   signed_by="${signed_by:${signed_by} }signed-by=$(sed -e ':a' -e '$!N' -e 's/\n/,/' -e 'ta' "$__object/parameter/signed-by")"
 fi
 
 if [ "$options" ]; then

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -31,11 +31,11 @@ fi
 component="$(cat "$__object/parameter/component")"
 
 if [ -f "$__object/parameter/arch" ]; then
-   options="arch=$(cat "$__object/parameter/arch")"
+	forcedarch="arch=$(cat "$__object/parameter/arch")"
 fi
 
 if [ -f "$__object/parameter/signed-by" ]; then
-   options="$options signed-by=$(cat "$__object/parameter/signed-by")"
+   signed_by="${signed_by:${signed_by} }signed-by=$(cat "$__object/parameter/signed-by")"
 fi
 
 if [ "$options" ]; then

--- a/type/__apt_source/manifest
+++ b/type/__apt_source/manifest
@@ -31,9 +31,15 @@ fi
 component="$(cat "$__object/parameter/component")"
 
 if [ -f "$__object/parameter/arch" ]; then
-   forcedarch="[arch=$(cat "$__object/parameter/arch")]"
-else
-   forcedarch=""
+   options="arch=$(cat "$__object/parameter/arch")"
+fi
+
+if [ -f "$__object/parameter/signed-by" ]; then
+   options="$options signed-by=$(cat "$__object/parameter/signed-by")"
+fi
+
+if [ "$options" ]; then
+    options="[$options]"
 fi
 
 # export variables for use in template
@@ -41,7 +47,7 @@ export name
 export uri
 export distribution
 export component
-export forcedarch
+export options
 
 # generate file from template
 mkdir "$__object/files"

--- a/type/__apt_source/parameter/optional
+++ b/type/__apt_source/parameter/optional
@@ -2,4 +2,3 @@ state
 distribution
 component
 arch
-signed-by

--- a/type/__apt_source/parameter/optional
+++ b/type/__apt_source/parameter/optional
@@ -2,3 +2,4 @@ state
 distribution
 component
 arch
+signed-by

--- a/type/__apt_source/parameter/optional_multiple
+++ b/type/__apt_source/parameter/optional_multiple
@@ -1,0 +1,1 @@
+signed-by


### PR DESCRIPTION
Allow users to specify a GPG key fingerprint or keyring file to be
included as the 'signed-by' option.