### PR TITLE
__apt_source: Fix source.list template for set -u

### DIFF
--- a/type/__apt_source/files/source.list.template
+++ b/type/__apt_source/files/source.list.template
@@ -2,8 +2,14 @@
 set -u
 
 entry="$uri $distribution $component"
-options="$forcedarch $signed_by"
-options=${options## }; options=${options%% }
+if test -n "${forcedarch-}"
+then
+   options=${options-}${options:+ }${forcedarch}
+fi
+if test -n "${signed_by-}"
+then
+   options=${options-}${options:+ }${signed_by}
+fi
 
 cat << DONE
 # Created by cdist ${__type##*/}


### PR DESCRIPTION
The previous version failed if either `$forcedarch` or `$signed_by` was not set.